### PR TITLE
Support setup_requirements

### DIFF
--- a/pip2nix.ini
+++ b/pip2nix.ini
@@ -3,3 +3,6 @@ requirements = .
 
 [pip2nix:package:pip2nix:args]
 makeWrapperArgs = '"--prefix PATH : ${pkgs.nix-prefetch-scripts}"'
+
+[pip2nix:package:mock]
+setup_requires = pbr

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'configobj>=5',
         'click',
         'contexter',
+        #'mock',
     ],
     tests_require=['pytest'],
     packages=['pip2nix', 'pip2nix.models'],
@@ -71,7 +72,8 @@ setup(
             "pip2nix%s=pip2nix.cli:cli" % sys.version[:3],
         ],
         "egg_info.writers": [
-            "tests_require.txt=pip2nix.egg_writer:write_arg"
+            "tests_require.txt=pip2nix.egg_writer:write_arg",
+            "setup_requires.txt=pip2nix.egg_writer:write_arg"
         ]
     }
 )


### PR DESCRIPTION
See also #11.
This has two parts:
- [ ] detecting setup_requires, and adding those packages to build-time deps
- [ ] letting user specify setup_requires in the config (for packages that crash without a given dep)

TODO:
- [ ] setup_requires should go into _build time_ deps, not runtime ones
- [ ] python setup_requires from configuration
- [ ] non-python setup_requires from configuration
