### PR TITLE
Avoid that py.test recurses into the result folder

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [pytest]
-norecursedirs = .* _bootstrap_env *.egg
+norecursedirs = .* _bootstrap_env *.egg result*


### PR DESCRIPTION
Found after running nix-build that py.test was recursing into the
subfolder "result" and got confused by the file test_requires.txt.

Got this output before the tweak:

```
[nix-shell:~/wo/pip2nix]$ py.test
============================================================ test session starts =============================================================
platform darwin -- Python 2.7.10, pytest-2.8.2, py-1.4.30, pluggy-0.3.1
rootdir: /Users/johannes/wo/pip2nix, inifile: setup.cfg
collected 11 items 

result/lib/python2.7/site-packages/pip2nix-0.2.0.dev1-py2.7.egg-info/tests_require.txt s
tests/test_config.py .....
tests/test_rendering.py ..
tests/test_utils.py ...
```
