### PR TITLE
Call pkg_info only if source_dir is present

### DIFF
--- a/pip2nix/models/package.py
+++ b/pip2nix/models/package.py
@@ -30,10 +30,16 @@ class PythonPackage(object):
     def from_requirements(cls, req, deps):
         pkg_info = req.pkg_info()
 
+        def name_version(dep):
+            return (
+                dep.name,
+                dep.pkg_info()['Version'] if dep.source_dir else None,
+            )
+
         return cls(
             name=req.name,
             version=pkg_info['Version'],
-            dependencies=[(d.name, d.pkg_info()['Version']) for d in deps],
+            dependencies=[name_version(d) for d in deps],
             source=req.link,
         )
 


### PR DESCRIPTION
Noticed that a dependency of a test dependency can fail if it is
already part of the normal dependencies. Since the version information
is not yet used anywhere, this should be safe enough.

I am not sure if this is the right way to avoid the issue, but it solved the problem on my end.
