### PR TITLE
Inject empty requirements for scaffold

### DIFF
--- a/pip2nix/cli.py
+++ b/pip2nix/cli.py
@@ -81,6 +81,9 @@ def scaffold(**kwargs):
     else:
         config.find_and_load()
     config.merge_cli_options(kwargs)
+    # TODO: Config enforces requirements to be specified, find a nicer
+    # way to let Config know that we don't need requirements here.
+    config.merge_options({'pip2nix': {'requirements': []}})
     config.validate()
 
     import jinja2


### PR DESCRIPTION
This allows to run "pip2nix scaffold" without having to inject
requirements via an INI file.

I have the feeling this is the wrong way to address it. The problem I faced was that `pip2nix scaffold` did not want to work. Probably it would work if I would add an INI file. Any thoughts on this?
