### PR TITLE
License extraction opt-in

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -25,7 +25,13 @@ let
   localOverrides = pythonPackages: {
     pip2nix = pythonPackages.pip2nix.override (attrs: {
       src = pip2nix-src;
-      buildInputs = [myPythonPackages.pip] ++ attrs.buildInputs;
+      buildInputs = [
+        myPythonPackages.pip
+        pkgs.nix
+      ] ++ attrs.buildInputs;
+      preBuild = ''
+        export NIX_PATH=nixpkgs=${pkgs.path}
+      '';
     });
   };
 

--- a/pip2nix/cli.py
+++ b/pip2nix/cli.py
@@ -44,7 +44,8 @@ def cli():
 @click.option('--requirement', '-r', multiple=True, type=click.Path(),
               metavar='<file>',
               help="Load specifiers from a requirements file.")
-@click.option('--licenses/--no-licenses', default=False)
+@click.option('--licenses/--no-licenses', default=False,
+              help="Extract license information as well, off by default.")
 @click.argument('specifiers', nargs=-1)
 def generate(specifiers, **kwargs):
     """Generate a .nix file with specified packages."""

--- a/pip2nix/cli.py
+++ b/pip2nix/cli.py
@@ -44,6 +44,7 @@ def cli():
 @click.option('--requirement', '-r', multiple=True, type=click.Path(),
               metavar='<file>',
               help="Load specifiers from a requirements file.")
+@click.option('--licenses/--no-licenses', default=False)
 @click.argument('specifiers', nargs=-1)
 def generate(specifiers, **kwargs):
     """Generate a .nix file with specified packages."""

--- a/pip2nix/config.py
+++ b/pip2nix/config.py
@@ -108,7 +108,8 @@ class Config(object):
         if requirements:
             options['requirements'] = requirements
 
-        for key in 'index_url', 'extra_index_url', 'no_index', 'output':
+        for key in ('index_url', 'extra_index_url', 'no_index', 'output',
+                    'licenses'):
             try:
                 value = cli_options[key]
                 if value is not None:

--- a/pip2nix/generate.py
+++ b/pip2nix/generate.py
@@ -107,17 +107,21 @@ class NixFreezeCommand(pip.commands.InstallCommand):
                 if pkg_config:
                     package.override(pkg_config)
 
+            include_lic = self.config['pip2nix']['licenses']
+
             with open(self.config['pip2nix']['output'], 'w') as f:
                 f.write('{\n')
                 f.write('  ' + indent(2, '\n'.join(
-                    '{} = {}'.format(pkg.name, pkg.to_nix())
+                    '{} = {}'.format(pkg.name,
+                                     pkg.to_nix(include_lic=include_lic))
                     for pkg in sorted(packages.values(),
                                       key=attrgetter('name'))
                 )))
 
                 f.write('\n\n### Test requirements\n\n')
                 f.write('  ' + indent(2, '\n'.join(
-                    '{} = {}'.format(pkg.name, pkg.to_nix())
+                    '{} = {}'.format(pkg.name,
+                                     pkg.to_nix(include_lic=include_lic))
                     for pkg in sorted(test_packages.values(),
                                       key=attrgetter('name'))
                 )))

--- a/pip2nix/models/package.py
+++ b/pip2nix/models/package.py
@@ -150,10 +150,7 @@ class PythonPackage(object):
         return template.format(args=indent(2, raw_args))
 
     def get_license_nix(self):
-        try:
-            licenses = self.get_licenses_from_setup()
-        except Exception:
-            licenses = self.get_licenses_from_pkginfo()
+        licenses = self.get_licenses_from_pkginfo()
 
         # Convert license strings to nix.
         nix_licenses = set()

--- a/pip2nix/models/package.py
+++ b/pip2nix/models/package.py
@@ -17,6 +17,7 @@ def get_nix_licenses():
         nix_licenses_json = check_output([
             'nix-instantiate', '--eval', '--expr',
             'with import <nixpkgs> { }; builtins.toJSON lib.licenses'])
+        nix_licenses_json = nix_licenses_json.decode('utf-8')
 
         # Dictionary which contains the contents of nixpkgs.lib.licenses.
         _nix_licenses = json.loads(json.loads(nix_licenses_json))

--- a/pip2nix/models/package.py
+++ b/pip2nix/models/package.py
@@ -160,26 +160,6 @@ class PythonPackage(object):
         template = '[ {licenses} ]'
         return template.format(licenses=' '.join(nix_licenses))
 
-    def get_licenses_from_setup(self):
-        """
-        Tries to load the license strings from setup.py script. This may raise
-        all kinds of exceptions because the setup script has to be executed.
-        """
-        from distutils import core
-        licenses = set()
-        dist = core.run_setup(self.pip_req.setup_py, stop_after='init')
-
-        # License string from setup() function.
-        licenses.add(dist.get_license())
-
-        # License strings from classifiers.
-        for classifier in dist.get_classifiers():
-            if classifier.startswith('License ::'):
-                lic = classifier.split('::')[-1]
-                licenses.add(lic.strip())
-
-        return filter_licenses(licenses)
-
     def get_licenses_from_pkginfo(self):
         """
         Parses the license string from PKG-INFO file.

--- a/pip2nix/models/package.py
+++ b/pip2nix/models/package.py
@@ -1,4 +1,27 @@
+import json
 import os
+
+from subprocess import check_output
+
+
+# TODO: Seems not very nice to do this here, maybe there is a better place
+# during app startup. And only executing when licenses flag is set.
+NIX_LICENSES_JSON = check_output([
+    'nix-instantiate', '--eval', '--expr',
+    'with import <nixpkgs> { }; builtins.toJSON lib.licenses'])
+
+# Dictionary which contains the contents of nixpkgs.lib.licenses.
+nix_licenses = json.loads(json.loads(NIX_LICENSES_JSON))
+
+# Mapping from license name in setup.py to attribute in nixpkgs.lib.licenses.
+LICENSE_NIX_MAP = {
+    'MIT': 'mit',
+    'ZPL 2.1': 'zpt21',
+}
+
+# Mapping to rename unresolved license names from setup.py files.
+LICENSE_RENAME_MAP = {
+}
 
 
 def indent(amount, string):
@@ -14,7 +37,7 @@ def indent(amount, string):
 
 
 class PythonPackage(object):
-    def __init__(self, name, version, dependencies, source):
+    def __init__(self, name, version, dependencies, source, pip_req):
         """
         :param dependencies: list of (name, version) pairs.
         """
@@ -25,6 +48,7 @@ class PythonPackage(object):
         self.source = source
         self.check = False
         self.test_dependencies = None
+        self.pip_req = pip_req
 
     @classmethod
     def from_requirements(cls, req, deps):
@@ -41,15 +65,21 @@ class PythonPackage(object):
             version=pkg_info['Version'],
             dependencies=[name_version(d) for d in deps],
             source=req.link,
+            pip_req=req,
         )
 
     def override(self, config):
         self.raw_args = config.get('args', {})
 
-    def to_nix(self):
+    def to_nix(self, include_lic):
         template = '\n'.join((
             'super.buildPythonPackage {{',
             '  {args}',
+            '}};',
+        ))
+        meta_template = '\n'.join((
+            'meta = {{',
+            '  {meta_args}',
             '}};',
         ))
 
@@ -67,12 +97,84 @@ class PythonPackage(object):
 
         args.update(self.raw_args)
 
+        # Prepare meta arguments.
+        meta_args = dict()
+        if include_lic:
+            license_nix = self.get_license_nix()
+            if license_nix:
+                meta_args['license'] = license_nix
+
         # Render name first
         raw_args = 'name = {};'.format(args.pop('name'))
         for k, v in sorted(args.items()):
             raw_args += '\n{} = {};'.format(k, v)
 
+        # Render meta arguments.
+        raw_meta_args = ''
+        for k, v in sorted(meta_args.items()):
+            raw_meta_args += '{} = {};\n'.format(k, v)
+        meta = meta_template.format(meta_args=indent(2, raw_meta_args))
+        raw_args += '\n{}'.format(meta)
+
         return template.format(args=indent(2, raw_args))
+
+    def get_license_nix(self):
+        license_str = self.get_license_string()
+        if license_str:
+            return license_to_nix(license_str)
+
+    def get_license_string(self):
+        """
+        Returns the license string set in setup.py as license argument to
+        setup or as classifier.
+        License argument takes precedence.
+        """
+        # TODO: Would be cool to get the info directly from setup.py
+        # but some setup.py scripts contain too much magic for run_setup()
+        #
+        # This was my approach to load it:
+        # from distutils import core
+        # print self.pip_req.setup_py
+        # dist = core.run_setup(self.pip_req.setup_py, stop_after='init')
+        # lic = dist.get_license()
+
+        data = self.pip_req.egg_info_data('PKG-INFO')
+
+        for line in data.split('\n'):
+
+            # Parse license from license argument.
+            if line.startswith(u'License: '):
+                lic = line.split('License: ')[-1]
+                lic = lic.strip()
+                if lic not in ['UNKNOWN']:
+                    return lic
+
+            # Parse license from classifiers.
+            elif line.startswith(u'Classifier: License ::'):
+                lic = line.split('::')[-1]
+                lic = lic.strip()
+                return lic
+
+
+def license_to_nix(license_name, nixpkgs='pkgs'):
+    template = '{nixpkgs}.lib.licenses.{attribute}'
+    full_name_template = '{{ fullName = "{full_name}"; }}'
+
+    # First try to fetch from custom mapping.
+    if license_name in LICENSE_NIX_MAP:
+        attr = LICENSE_NIX_MAP.get(license_name)
+        return template.format(nixpkgs=nixpkgs, attribute=attr)
+
+    # Otherwise try to lookup in licenses from nix.
+    for attr, nix_license_data in nix_licenses.items():
+        if license_name in nix_license_data.values():
+            return template.format(nixpkgs=nixpkgs, attribute=attr)
+
+    # Had no luck converting the license name to a license in
+    # nixpkgs.lib.licenses. In this case we can at least store a set with
+    # the fullName attribute like in nix licenses.
+    license_name = LICENSE_RENAME_MAP.get(license_name, license_name)
+    return full_name_template.format(full_name=license_name)
 
 
 def link_to_nix(link):

--- a/python-packages.nix
+++ b/python-packages.nix
@@ -5,18 +5,18 @@
     doCheck = false;
     propagatedBuildInputs = with self; [];
     src = fetchurl {
-      url = "https://pypi.python.org/packages/source/M/MarkupSafe/MarkupSafe-0.23.tar.gz";
+      url = "https://pypi.python.org/packages/c0/41/bae1254e0396c0cc8cf1751cb7d9afc90a602353695af5952530482c963f/MarkupSafe-0.23.tar.gz";
       md5 = "f5ab3deee4c37cd6a922fb81e730da6e";
     };
   };
   click = super.buildPythonPackage {
-    name = "click-6.3";
+    name = "click-6.6";
     buildInputs = with self; [];
     doCheck = false;
     propagatedBuildInputs = with self; [];
     src = fetchurl {
-      url = "https://pypi.python.org/packages/source/c/click/click-6.3.tar.gz";
-      md5 = "2f171cdf12b8f2e284c224825f5e4634";
+      url = "https://pypi.python.org/packages/7a/00/c14926d8232b36b08218067bcd5853caefb4737cda3f0a47437151344792/click-6.6.tar.gz";
+      md5 = "d0b09582123605220ad6977175f3e51d";
     };
   };
   configobj = super.buildPythonPackage {
@@ -25,7 +25,7 @@
     doCheck = false;
     propagatedBuildInputs = with self; [six];
     src = fetchurl {
-      url = "https://pypi.python.org/packages/source/c/configobj/configobj-5.0.6.tar.gz";
+      url = "https://pypi.python.org/packages/64/61/079eb60459c44929e684fa7d9e2fdca403f67d64dd9dbac27296be2e0fab/configobj-5.0.6.tar.gz";
       md5 = "e472a3a1c2a67bb0ec9b5d54c13a47d6";
     };
   };
@@ -35,7 +35,7 @@
     doCheck = false;
     propagatedBuildInputs = with self; [];
     src = fetchurl {
-      url = "https://pypi.python.org/packages/source/c/contexter/contexter-0.1.3.tar.gz";
+      url = "https://pypi.python.org/packages/f4/a4/a42a6401bfe2a05fe63e328a8e1b37881e4c286a8029fec1577949d6a8b5/contexter-0.1.3.tar.gz";
       md5 = "437efd28f5489cccfe929c08c6b269aa";
     };
   };
@@ -45,18 +45,18 @@
     doCheck = false;
     propagatedBuildInputs = with self; [MarkupSafe];
     src = fetchurl {
-      url = "https://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.8.tar.gz";
+      url = "https://pypi.python.org/packages/f2/2f/0b98b06a345a761bec91a079ccae392d282690c2d8272e708f4d10829e22/Jinja2-2.8.tar.gz";
       md5 = "edb51693fe22c53cee5403775c71a99e";
     };
   };
   pip = super.buildPythonPackage {
-    name = "pip-8.1.1";
+    name = "pip-8.1.2";
     buildInputs = with self; [];
     doCheck = false;
     propagatedBuildInputs = with self; [];
     src = fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pip/pip-8.1.1.tar.gz";
-      md5 = "6b86f11841e89c8241d689956ba99ed7";
+      url = "https://pypi.python.org/packages/e7/a8/7556133689add8d1a54c0b14aeff0acb03c64707ce100ecd53934da1aa13/pip-8.1.2.tar.gz";
+      md5 = "87083c0b9867963b29f7aba3613e8f4a";
     };
   };
   pip2nix = super.buildPythonPackage {
@@ -73,7 +73,7 @@
     doCheck = false;
     propagatedBuildInputs = with self; [];
     src = fetchurl {
-      url = "https://pypi.python.org/packages/source/s/six/six-1.10.0.tar.gz";
+      url = "https://pypi.python.org/packages/b3/b2/238e2590826bfdd113244a40d9d3eb26918bd798fc187e2360a8367068db/six-1.10.0.tar.gz";
       md5 = "34eed507548117b2ab523ab14b2f8b55";
     };
   };
@@ -86,18 +86,18 @@
     doCheck = false;
     propagatedBuildInputs = with self; [];
     src = fetchurl {
-      url = "https://pypi.python.org/packages/source/p/py/py-1.4.31.tar.gz";
+      url = "https://pypi.python.org/packages/f4/9a/8dfda23f36600dd701c6722316ba8a3ab4b990261f83e7d3ffc6dfedf7ef/py-1.4.31.tar.gz";
       md5 = "5d2c63c56dc3f2115ec35c066ecd582b";
     };
   };
   pytest = super.buildPythonPackage {
-    name = "pytest-2.9.1";
+    name = "pytest-3.0.2";
     buildInputs = with self; [];
     doCheck = false;
     propagatedBuildInputs = with self; [py];
     src = fetchurl {
-      url = "https://pypi.python.org/packages/source/p/pytest/pytest-2.9.1.tar.gz";
-      md5 = "05165740ea50928e4e971378630163ec";
+      url = "https://pypi.python.org/packages/2b/05/e20806c99afaff43331f5fd8770bb346145303882f98ef3275fa1dd66f6d/pytest-3.0.2.tar.gz";
+      md5 = "61dc36e65a6f6c11c53b1388e043a9f5";
     };
   };
 }

--- a/tests/models/test_package.py
+++ b/tests/models/test_package.py
@@ -14,7 +14,7 @@ def raise_on_call(*args, **kwargs):
 
 def test_loads_data_once(monkeypatch):
     stub_data = {'stub': {'attr': 'value'}}
-    stub_value = json.dumps(json.dumps(stub_data))
+    stub_value = json.dumps(json.dumps(stub_data)).encode('utf-8')
     package._nix_licenses = None
 
     monkeypatch.setattr(package, 'check_output', lambda *args: stub_value)

--- a/tests/models/test_package.py
+++ b/tests/models/test_package.py
@@ -1,0 +1,25 @@
+import json
+
+from pip2nix.models import package
+
+
+def test_get_nix_licenses():
+    licenses = package.get_nix_licenses()
+    assert 'gpl3' in licenses
+
+
+def raise_on_call(*args, **kwargs):
+    raise Exception("Must not be called")
+
+
+def test_loads_data_once(monkeypatch):
+    stub_data = {'stub': {'attr': 'value'}}
+    stub_value = json.dumps(json.dumps(stub_data))
+    package._nix_licenses = None
+
+    monkeypatch.setattr(package, 'check_output', lambda *args: stub_value)
+    package.get_nix_licenses()
+    monkeypatch.setattr(package, 'check_output', raise_on_call)
+    package.get_nix_licenses()
+
+    assert package._nix_licenses == stub_data


### PR DESCRIPTION
We try to extract the license from the egg-info information of required packages. The use case is to use the nix dependency tree to generate an overview of all third party packages and also a semi-automatic license verification in case your corporate environment or project poses some constraints.

It's based on a best effort principle: If the information is there and we can understand it, then we try to set `meta.license` based on `pkgs.lib.licenses`, otherwise we take the string value.

In our project we use this to get the license information for about 90% of our dependencies, the rest is something we fill in manually with an override layer. That seems to be a good trade-off so far.

What do you think about adding support for this? The code is not yet fully ready for inclusion I think, but maybe good enough for some early feedback on it. If you think that's useful, we can bring it into good shape so that it is ready for inclusion.
