### PR TITLE
Add support for ``--find-links``

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@
 ===========
 
 
+- Add support for ``--find-links`` pip option.
+
+
 0.8.0
 =====
 

--- a/pip2nix/cli.py
+++ b/pip2nix/cli.py
@@ -26,8 +26,8 @@ def cli():
               help="Extra index URLs to use.")
 @click.option('--no-index/--index',
               help="Ignore indexes.")
-#@click.option('--find-links', '-f', metavar='<url>',
-#              help="Path or url to a package listing/directory.")
+@click.option('--find-links', '-f', metavar='<url>', multiple=True,
+              help="Path or url to a package listing/directory.")
 
 #TODO:
 # --allow-external <package>  Allow the installation of a package even if it is externally hosted

--- a/pip2nix/config.py
+++ b/pip2nix/config.py
@@ -113,7 +113,7 @@ class Config(object):
             options['constraints'] = constraints
 
         for key in ('index_url', 'extra_index_url', 'no_index', 'output',
-                    'licenses', 'only_direct'):
+                    'licenses', 'only_direct', 'find_links'):
             try:
                 value = cli_options[key]
                 if value is not None:

--- a/pip2nix/generate.py
+++ b/pip2nix/generate.py
@@ -202,6 +202,7 @@ class NixFreezeCommand(pip.commands.InstallCommand):
                 ('output', ('output', )),
                 ('build', ('build', )),
                 ('download', ('download',)),
+                ('find_links', ('find_links', )),
                 ('src', ('src',))]:
             value = self.config.get_config('pip2nix', *path)
             if value is not None:


### PR DESCRIPTION
I'd like to add (or restore) support for ``--find-links`` option, which makes it easier to generate requirements with a lot of internal packages without proper package index.

This worked for me. I'm not sure, how this could or should be properly tested.