### PR TITLE
Migrate to pip >= 18 without excluding support for test requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .cache/
+.idea/
 *.pyc
 /*.egg-info/
 /result

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   - ATTR=pip2nix.python35
   - ATTR=pip2nix.python36
   - ATTR=pip2nix.python37
-  - ATTR=pip2nix.python38
   - ATTR=docs
   - MODE=bootstrap
 install: bash <(curl https://nixos.org/nix/install)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,10 @@ sudo: required
 dist: trusty
 env:
   - ATTR=pip2nix.python27
-  # TODO: pytest installation fails
-  # - ATTR=pip2nix.python33
-  - ATTR=pip2nix.python34
-  - ATTR=pip2nix.python35
   - ATTR=pip2nix.python35
   - ATTR=pip2nix.python36
+  - ATTR=pip2nix.python37
+  - ATTR=pip2nix.python38
   - ATTR=docs
   - MODE=bootstrap
 install: bash <(curl https://nixos.org/nix/install)

--- a/pip2nix/generate.py
+++ b/pip2nix/generate.py
@@ -112,7 +112,7 @@ class NixFreezeCommand(InstallCommand):
     def super_run(self, options, args):
         """Copy of relevant parts from InstallCommand's run()"""
 
-        upgrade_strategy = "to-satisfy-only"
+        upgrade_strategy = "eager"
         if options.upgrade:
             upgrade_strategy = options.upgrade_strategy
 

--- a/pip2nix/generate.py
+++ b/pip2nix/generate.py
@@ -8,7 +8,10 @@ from operator import attrgetter
 import os
 import shutil
 
-from pip._internal import cmdoptions
+try:
+    from pip._internal.cli import cmdoptions
+except:
+    from pip._internal import cmdoptions
 from pip._internal.cache import WheelCache
 from pip._internal.commands.install import InstallCommand
 from pip._internal.operations.prepare import RequirementPreparer

--- a/pip2nix/generate.py
+++ b/pip2nix/generate.py
@@ -18,7 +18,10 @@ from pip._internal.commands.install import InstallCommand
 from pip._internal.operations.prepare import RequirementPreparer
 from pip._internal.req import RequirementSet
 from pip._internal.req.req_tracker import RequirementTracker
-from pip._internal.resolve import Resolver
+try:
+    from pip._internal.resolve import Resolver
+except ImportError:
+    from pip._internal.legacy_resolve import Resolver
 from pip._internal.utils.temp_dir import TempDirectory
 
 try:

--- a/pip2nix/models/package.py
+++ b/pip2nix/models/package.py
@@ -153,9 +153,18 @@ class PythonPackage(object):
                                 in self.dependencies)) + '\n]'
             ))
 
+        try:
+            if self.source.url_without_fragment.endswith('zip'):
+                args.update(dict(
+                    nativeBuildInputs ='[\n  ' + (
+                        '\n  '.join(['pkgs."unzip"'])) + '\n]'
+                ))
+        except AttributeError:
+            pass
+
         if self.test_dependencies:
             args.update(dict(
-                buildInputs='[\n  ' + (
+                checkInputs='[\n  ' + (
                     '\n  '.join('self."{}"'.format(name) for name, version
                             in self.test_dependencies or ())) + '\n]'
             ))

--- a/pip2nix/models/package.py
+++ b/pip2nix/models/package.py
@@ -4,6 +4,11 @@ import pkg_resources
 from subprocess import check_output, STDOUT
 from operator import itemgetter
 
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = OSError
+
 
 _nix_licenses = None
 
@@ -84,7 +89,6 @@ def get_version(req):
     except FileNotFoundError:
         for dist in pkg_resources.find_on_path(None, req.source_dir):
             return dist.version
-    import pdb; pdb.set_trace()
 
 
 class PythonPackage(object):

--- a/pip2nix/models/package.py
+++ b/pip2nix/models/package.py
@@ -154,7 +154,7 @@ class PythonPackage(object):
             ))
 
         try:
-            if self.source.url_without_fragment.endswith('zip'):
+            if self.source.url_without_fragment.endswith('.zip'):
                 args.update(dict(
                     nativeBuildInputs ='[\n  ' + (
                         '\n  '.join(['pkgs."unzip"'])) + '\n]'

--- a/pip2nix/models/package.py
+++ b/pip2nix/models/package.py
@@ -2,6 +2,7 @@ import json
 import os
 import pkg_resources
 from subprocess import check_output, STDOUT
+from operator import itemgetter
 
 
 _nix_licenses = None
@@ -111,7 +112,8 @@ class PythonPackage(object):
         return cls(
             name=req.name,
             version=get_version(req),
-            dependencies=[name_version(d) for d in deps],
+            dependencies=sorted([name_version(d) for d in deps],
+                                key=itemgetter(0)),
             source=finder.find_requirement(req, upgrade=False),
             pip_req=req,
         )

--- a/pip2nix/models/package.py
+++ b/pip2nix/models/package.py
@@ -108,13 +108,16 @@ class PythonPackage(object):
                 dep.name,
                 get_version(dep),
             )
-
+        source = req.link
+        if source.path.endswith('.whl') or source.path.endswith('.egg'):
+            # replace wheels and eggs with sdists
+            source=finder.find_requirement(req, upgrade=False)
         return cls(
             name=req.name,
             version=get_version(req),
             dependencies=sorted([name_version(d) for d in deps],
                                 key=itemgetter(0)),
-            source=finder.find_requirement(req, upgrade=False),
+            source=source,
             pip_req=req,
         )
 

--- a/pip2nix/models/requirement_set.py
+++ b/pip2nix/models/requirement_set.py
@@ -1,4 +1,4 @@
-from pip.req import RequirementSet
+from pip._internal.req.req_set import RequirementSet
 
 
 class RequirementSetLayer(RequirementSet):

--- a/python-packages.nix
+++ b/python-packages.nix
@@ -55,13 +55,13 @@ self: super: {
     };
   };
   pip = super.buildPythonPackage {
-    name = "pip-9.0.1";
+    name = "pip-19.2.2";
     buildInputs = with self; [];
     doCheck = false;
     propagatedBuildInputs = with self; [];
     src = fetchurl {
-      url = "https://pypi.python.org/packages/11/b6/abcb525026a4be042b486df43905d6893fb04f05aac21c32c638e939e447/pip-9.0.1.tar.gz";
-      sha256 = "03clr9c1dih5n9c00c592zzvf6r1ffimywkaq9agcqdllzhl7wh9";
+      url = "https://files.pythonhosted.org/packages/aa/1a/62fb0b95b1572c76dbc3cc31124a8b6866cbe9139eb7659ac7349457cf7c/pip-19.2.2.tar.gz";
+      sha256 = "e05103825871e210d50a44c7e448587b0ed99dd775d3ef586304c58f40224a53";
     };
   };
   pip2nix = super.buildPythonPackage {

--- a/release.nix
+++ b/release.nix
@@ -22,6 +22,7 @@ let
           {pythonVersion = "35";}
         ] ++ optional (hasAttr "python33Packages" pkgs) {pythonVersion = "33";}
         ++ optional (hasAttr "python36Packages" pkgs) {pythonVersion = "36";}
+        ++ optional (hasAttr "python37Packages" pkgs) {pythonVersion = "37";}
         ))
       )
     );

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     keywords='nix pip',
 
     install_requires=[
-        'pip>=8,<10',
+        'pip>=18',
         'configobj>=5',
         'click',
         'contexter',

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,5 +1,5 @@
 import os
-from pip.index import Link
+from pip._internal.index import Link
 from pip2nix.models.package import link_to_nix
 import pytest
 


### PR DESCRIPTION
I opened this pull request to discuss about pip >= 18 support.

Currently support for test requirements is missing and I have only tried this yet with a few builds.