### PR TITLE
Fix typo in default.nix

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -11,7 +11,7 @@ let
       inherit (pkgs) lib;
     }).gitignoreSource;
 
-    # pip2nix requires pip versio from nixos-20.03
+    # pip2nix requires pip version from nixos-20.03
     pip2nix = ((import (sources.pip2nix + "/release.nix") {
       pkgs = import sources."nixpkgs-20.03" {};
     }).pip2nix);


### PR DESCRIPTION
Side note: What is the reason that this is tied to 20.03? When can it be updated?