### PR TITLE
Change process requirements to use directly pkg version when required

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
           - nixpkgs: nixpkgs-18.09
             python: python39
     steps:
-    - uses: actions/checkout@v2.3.4
-    - uses: cachix/install-nix-action@v12
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v16
       with:
         nix_path: nixpkgs=channel:nixos-unstable
     - run: nix-build release.nix --argstr nixpkgs ${{ matrix.nixpkgs }} -A pip2nix.${{ matrix.python }}

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,7 +24,7 @@ done
 
 NIXPKGS="${NIXPKGS:-nixpkgs-20.09}"
 PYTHON="${PYTHON:-python39}"
-PIP=$(nix eval "(import ./nix { nixpkgs = (import ./nix/sources.nix).\"$NIXPKGS\"; }).${PYTHON}Packages.pip.version")
+PIP=$(nix-instantiate --eval -E "(import ./nix { nixpkgs = (import ./nix/sources.nix).\"$NIXPKGS\"; }).${PYTHON}Packages.pip.version")
 PIP=${PIP//\"/}
 
 if [ "$FORCE_REBUILD" -o \

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
-{ pkgs ? (import <nixpkgs> {})
-, pythonPackages ? "python36Packages"
+{ pkgs ? import ./nix {}
+, sources ? import ./nix/sources.nix
+, pythonPackages ? "python39Packages"
 }:
 
 with pkgs.lib;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? sources."nixpkgs-20.03"
+{ nixpkgs ? sources."nixpkgs-20.09"
 , config ? {}
 , sources ? import ./sources.nix
 }:

--- a/pip2nix/generate.py
+++ b/pip2nix/generate.py
@@ -132,17 +132,20 @@ class NixFreezeCommand(InstallCommand):
                 resolver.resolve(indirect_deps, check_supported_wheels=True)
             for req in requirements.values():
                 if not req.source_dir:
+                    req.is_direct = True
                     resolver.resolve([req], check_supported_wheels=True)
                 try:
                     packages[req.name] = PythonPackage.from_requirements(
-                        requirement_set.requirements[req.name],
+                        req,
+#                       requirement_set.requirements[req.name],
                         resolver._discovered_dependencies.get(req.name, []),
                         finder, self.config["pip2nix"].get("check_inputs")
                     )
                 except KeyError:
                     req.req.name = req.name.lower()  # try to work around case differences
                     packages[req.name] = PythonPackage.from_requirements(
-                        requirement_set.requirements[req.name],
+                        req,
+#                       requirement_set.requirements[req.name],
                         resolver._discovered_dependencies.get(req.name, []),
                         finder, self.config["pip2nix"].get("check_inputs")
                     )

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? (import <nixpkgs> {})
+{ pkgs ? import ./nix {}
 }:
 
 pkgs.mkShell {


### PR DESCRIPTION
Possibly fixes #76 #77

Could include regression.