### PR TITLE
Send extra index urls and build dir to pip

### DIFF
--- a/pip2nix/cli.py
+++ b/pip2nix/cli.py
@@ -24,7 +24,7 @@ def cli():
               help="Only render direct dependencies.")
 @click.option('--index-url', '-i', metavar='<url>',
               help="Base URL of Python Package Index.")
-@click.option('--extra-index-url', metavar='<url>',
+@click.option('--extra-index-url', multiple=True, metavar='<url>',
               help="Extra index URLs to use.")
 @click.option('--no-index/--index',
               help="Ignore indexes.")

--- a/pip2nix/config.py
+++ b/pip2nix/config.py
@@ -113,7 +113,8 @@ class Config(object):
             options['constraints'] = constraints
 
         for key in ('index_url', 'extra_index_url', 'no_index', 'output',
-                    'licenses', 'only_direct', 'no_binary', 'check_inputs'):
+                    'licenses', 'only_direct', 'no_binary', 'check_inputs',
+                    'build_dir'):
             try:
                 value = cli_options[key]
                 if value is not None:

--- a/pip2nix/generate.py
+++ b/pip2nix/generate.py
@@ -351,7 +351,7 @@ class NixFreezeCommand(InstallCommand):
 
         Returns a (options, args) tuple."""
         for opt_name, path in [
-                ('build', ('build', )),
+                ('build_dir', ('build_dir', )),
                 ('download', ('download',)),
                 ('index_url', ('index_url', )),
                 ('extra_index_urls', ('extra_index_url', )),

--- a/pip2nix/generate.py
+++ b/pip2nix/generate.py
@@ -354,6 +354,7 @@ class NixFreezeCommand(InstallCommand):
                 ('build', ('build', )),
                 ('download', ('download',)),
                 ('index_url', ('index_url', )),
+                ('extra_index_urls', ('extra_index_url', )),
                 ('no_binary', ('no_binary', )),
                 ('output', ('output', )),
                 ('src', ('src',))]:


### PR DESCRIPTION
This PR fixes the following issue:

1. Providing an extra index url fails.
2. Providing a build dir is simply ignored.

The first issue is associated to an incorrect definition of the CLI options. To reproduce, one can run for example: `pip2nix generate -r project/requirements.txt --extra-index-url https://download.pytorch.org/whl/cu113`. The expected behavior is for the extra index url to be sent to pip. But instead, the actual behavior is the following failure:

```text
Traceback (most recent call last):
  File "/nix/store/rwcgjzbf1g7ibz6yirkbpkyasmq92zli-python3.9-pip2nix-0.9.0.dev1/bin/..pip2nix-wrapped-wrapped", line 9, in <module>
    sys.exit(cli())
  File "/nix/store/dz6l6fbpyfj6l1j418yh5fi4bpgpvnaz-python3.9-click-7.1.2/lib/python3.9/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/nix/store/dz6l6fbpyfj6l1j418yh5fi4bpgpvnaz-python3.9-click-7.1.2/lib/python3.9/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/nix/store/dz6l6fbpyfj6l1j418yh5fi4bpgpvnaz-python3.9-click-7.1.2/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/nix/store/dz6l6fbpyfj6l1j418yh5fi4bpgpvnaz-python3.9-click-7.1.2/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/nix/store/dz6l6fbpyfj6l1j418yh5fi4bpgpvnaz-python3.9-click-7.1.2/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/nix/store/rwcgjzbf1g7ibz6yirkbpkyasmq92zli-python3.9-pip2nix-0.9.0.dev1/lib/python3.9/site-packages/pip2nix/cli.py", line 70, in generate
    config.validate()
  File "/nix/store/rwcgjzbf1g7ibz6yirkbpkyasmq92zli-python3.9-pip2nix-0.9.0.dev1/lib/python3.9/site-packages/pip2nix/config.py", line 57, in validate
    raise ValidationError(err_msg)
pip2nix.config.ValidationError: pip2nix.extra_index_url: the value "https://download.pytorch.org/whl/cu113" is of the wrong type.
```

For the second issue, it turns out that providing a build directory with `-b` is not forwarded to pip and is simply ignored. The expected behavior is for pip2nix to send the option to pip so that it uses said directory for building. The actual behavior is that the system temporary folder (usually `/tmp`) is used instead.