### PR TITLE
fix: Correct check if a requirement is a direct requirement

### DIFF
--- a/pip2nix/generate.py
+++ b/pip2nix/generate.py
@@ -87,7 +87,7 @@ class NixFreezeCommand(InstallCommand):
         if self.config.get_config('pip2nix', 'only_direct'):
             packages_base = [
                 r for r in requirement_set.requirements.values()
-                if r.is_direct and not r.comes_from.startswith('-c ')]
+                if _is_direct_requirement(r)]
         else:
             try:
                 packages_base = requirement_set.all_requirements
@@ -390,3 +390,11 @@ def generate(config):
     cmd = NixFreezeCommand(config)
 
     return cmd.main([])
+
+
+def _is_direct_requirement(r):
+    return r.is_direct and not _comes_from_constraint(r)
+
+
+def _comes_from_constraint(r):
+    return r.comes_from and r.comes_from.startswith('-c ')

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+from pip2nix.generate import _is_direct_requirement
+
+
+def test_is_direct_requirement_without_comes_from_considered_direct():
+    stub_requirement = mock.Mock()
+    stub_requirement.is_direct = True
+    stub_requirement.comes_from = None
+
+    assert _is_direct_requirement(stub_requirement)
+
+
+def test_is_direct_requirement_from_constraints_not_considered_direct():
+    stub_requirement = mock.Mock()
+    stub_requirement.is_direct = True
+    stub_requirement.comes_from = "-c module-constraints.txt"
+
+    assert not _is_direct_requirement(stub_requirement)


### PR DESCRIPTION
"r.comes_from" can be "None" if a requirement is directly specified and not listed in a requirements file.

I've noticed the following traceback:

```
ERROR: Exception:
Traceback (most recent call last):
  File "/nix/store/r3g6kc8h7li85wbsnnw07053kghc8wb2-python3.10-pip-20.1.1/lib/python3.10/site-packages/pip/_internal/cli/base_command.py", line 188, in _main
    status = self.run(options, args)
  File "/nix/store/kvqpw2w6ck254qp99jn84y66yr3sg2nv-python3.10-pip2nix-0.9.0.dev1/lib/python3.10/site-packages/pip2nix/generate.py", line 343, in run
    with Contexter() as ctx:
  File "/nix/store/gda35s57qcxrmmfj28qw7n1izqs1zc25-python3.10-contexter-0.1.4/lib/python3.10/site-packages/contexter.py", line 96, in __exit__
    reraise(exc)
  File "/nix/store/gda35s57qcxrmmfj28qw7n1izqs1zc25-python3.10-contexter-0.1.4/lib/python3.10/site-packages/contexter.py", line 26, in reraise
    raise exc[1].with_traceback(exc[2])
  File "/nix/store/kvqpw2w6ck254qp99jn84y66yr3sg2nv-python3.10-pip2nix-0.9.0.dev1/lib/python3.10/site-packages/pip2nix/generate.py", line 346, in run
    requirement_set = self.super_run(options, args)
  File "/nix/store/kvqpw2w6ck254qp99jn84y66yr3sg2nv-python3.10-pip2nix-0.9.0.dev1/lib/python3.10/site-packages/pip2nix/generate.py", line 325, in super_run
    self.process_requirements(
  File "/nix/store/kvqpw2w6ck254qp99jn84y66yr3sg2nv-python3.10-pip2nix-0.9.0.dev1/lib/python3.10/site-packages/pip2nix/generate.py", line 88, in process_requirements
    packages_base = [
  File "/nix/store/kvqpw2w6ck254qp99jn84y66yr3sg2nv-python3.10-pip2nix-0.9.0.dev1/lib/python3.10/site-packages/pip2nix/generate.py", line 90, in <listcomp>
    if r.is_direct and not r.comes_from.startswith('-c ')]
AttributeError: 'NoneType' object has no attribute 'startswith'
```

Found the issue while running the following command:

```
pip2nix generate trytond
```
